### PR TITLE
Add to context menu

### DIFF
--- a/Assets/Scripts/editor/SpriteTextureSliceExporter.cs
+++ b/Assets/Scripts/editor/SpriteTextureSliceExporter.cs
@@ -22,6 +22,7 @@ public class SpriteTextureSliceExporter : ScriptableObject
         return outputDirectory;
     }
 
+    [MenuItem("Assets/Export Slices")]
     [MenuItem("SpriteTextureSliceExporter/Export Slices")]
     public static void ExportSlices() {
         var outputDirectory = GetOutputDirectory();
@@ -55,6 +56,7 @@ public class SpriteTextureSliceExporter : ScriptableObject
         }
     }
     
+    [MenuItem("Assets/Export Slices", true)]
     [MenuItem("SpriteTextureSliceExporter/Export Slices", true)]
     public static bool ExportSlicesValidation() {
         return Selection.activeObject as Texture2D != null;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5695c1e8-ea7b-4719-94c6-2d0a343a254b)
Unfortunately it doesn't look like there's a way to prevent the item from _appearing_ if validation is not passed, but it's not clickable at least. This is compatible with the validation added in my other pr, but seperated in case you didn't want one or the other :)
Thanks